### PR TITLE
feat: show narratives in StacInfo

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -153,7 +153,11 @@ export default {
                     name: "EodashStacInfo",
                     properties: {
                       body: ["description"],
-                      featured: ["providers", "assets"],
+                      featured: [
+                        "providers",
+                        { key: "eodash:narratives" },
+                        { key: "assets", filter: (asset) => !(asset?.roles?.includes("story"))}
+                      ],
                     },
                   },
                 }


### PR DESCRIPTION
- enables display of the links to narratives
Like so, except that `Stories` will be `Narratives`
<img width="595" height="351" alt="image" src="https://github.com/user-attachments/assets/1846b5ba-5c59-4e1d-ba3d-27a1c940e4e9" />
